### PR TITLE
Remove empty signMessage from wallets that do not implement it

### DIFF
--- a/packages/coin98-wallet/src/lib/coin98-wallet.ts
+++ b/packages/coin98-wallet/src/lib/coin98-wallet.ts
@@ -182,18 +182,6 @@ const Coin98Wallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
-
-    async signMessage({ message, nonce, recipient, callbackUrl, state }) {
-      logger.log("Coin98Wallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        callbackUrl,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -283,7 +283,7 @@ export class WalletModules {
         );
       }
 
-      return _signMessage(params);
+      return await _signMessage(params);
     };
 
     return wallet;

--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -256,6 +256,7 @@ export class WalletModules {
   private decorateWallet(wallet: Wallet): Wallet {
     const _signIn = wallet.signIn;
     const _signOut = wallet.signOut;
+    const _signMessage = wallet.signMessage;
 
     wallet.signIn = async (params: never) => {
       const accounts = await _signIn(params);
@@ -273,6 +274,16 @@ export class WalletModules {
     wallet.signOut = async () => {
       await _signOut();
       this.onWalletSignedOut(wallet.id);
+    };
+
+    wallet.signMessage = async (params: never) => {
+      if (_signMessage === undefined) {
+        throw Error(
+          `The signMessage method is not supported by ${wallet.metadata.name}`
+        );
+      }
+
+      return _signMessage(params);
     };
 
     return wallet;

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -80,7 +80,7 @@ interface BaseWalletBehaviour {
   signAndSendTransactions(
     params: SignAndSendTransactionsParams
   ): Promise<Array<providers.FinalExecutionOutcome>>;
-  signMessage(params: SignMessageParams): Promise<SignedMessage | void>;
+  signMessage?(params: SignMessageParams): Promise<SignedMessage | void>;
 }
 
 type BaseWallet<

--- a/packages/finer-wallet/src/lib/finer-injected.ts
+++ b/packages/finer-wallet/src/lib/finer-injected.ts
@@ -279,17 +279,6 @@ const FinerExtension: WalletBehaviourFactory<InjectedWallet> = async ({
           return res.response;
         });
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("FinerWallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/ledger/src/lib/ledger.ts
+++ b/packages/ledger/src/lib/ledger.ts
@@ -276,17 +276,6 @@ const Ledger: WalletBehaviourFactory<HardwareWallet> = async ({
 
       return await _state.client.getPublicKey({ derivationPath });
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Ledger:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/math-wallet/src/lib/math-wallet.ts
+++ b/packages/math-wallet/src/lib/math-wallet.ts
@@ -181,17 +181,6 @@ const MathWallet: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return results;
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("MathWallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/my-near-wallet/src/lib/my-near-wallet.ts
+++ b/packages/my-near-wallet/src/lib/my-near-wallet.ts
@@ -224,18 +224,6 @@ const MyNearWallet: WalletBehaviourFactory<
       });
     },
 
-    async signMessage({ message, nonce, recipient, callbackUrl, state }) {
-      logger.log("MyNearWallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        callbackUrl,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
-
     buildImportAccountsUrl() {
       return `${params.walletUrl}/batch-import`;
     },

--- a/packages/narwallets/src/lib/narwallets.ts
+++ b/packages/narwallets/src/lib/narwallets.ts
@@ -263,17 +263,6 @@ const Narwallets: WalletBehaviourFactory<InjectedWallet> = async ({
         Array<FinalExecutionOutcome>
       >;
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("NarWallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/near-snap/src/lib/near-snap.ts
+++ b/packages/near-snap/src/lib/near-snap.ts
@@ -15,7 +15,6 @@ const NearSnapWallet: WalletBehaviourFactory<InjectedWallet> = async ({
   provider,
   store,
   metadata,
-  logger,
 }) => {
   const network = options.network.networkId as "testnet" | "mainnet";
 
@@ -79,17 +78,6 @@ const NearSnapWallet: WalletBehaviourFactory<InjectedWallet> = async ({
       );
 
       return Promise.all(signedTxs.map((tx) => provider.sendTransaction(tx)));
-    },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("NearSnap:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
     },
   };
 };

--- a/packages/nearfi/src/lib/nearfi.ts
+++ b/packages/nearfi/src/lib/nearfi.ts
@@ -223,17 +223,6 @@ const NearFi: WalletBehaviourFactory<InjectedWallet> = async ({
           return res.response;
         });
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("NearFi:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/neth/src/lib/neth.ts
+++ b/packages/neth/src/lib/neth.ts
@@ -176,17 +176,6 @@ const Neth: WalletBehaviourFactory<InjectedWallet> = async ({
 
     signAndSendTransactions: async ({ transactions }) =>
       signTransactions(transactions),
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Neth:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/nightly-connect/src/lib/nightly-connect.ts
+++ b/packages/nightly-connect/src/lib/nightly-connect.ts
@@ -270,17 +270,6 @@ const NightlyConnect: WalletBehaviourFactory<
 
       return results;
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("NightlyConnect:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/nightly/src/lib/nightly.ts
+++ b/packages/nightly/src/lib/nightly.ts
@@ -224,17 +224,6 @@ const Nightly: WalletBehaviourFactory<InjectedWallet> = async ({
     async importAccountsInSecureContext(params) {
       _state.wallet.importWalletsNear(params.accounts);
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Nightly:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/opto-wallet/src/lib/opto-wallet.ts
+++ b/packages/opto-wallet/src/lib/opto-wallet.ts
@@ -227,18 +227,6 @@ const OptoWallet: WalletBehaviourFactory<
         callbackUrl,
       });
     },
-
-    async signMessage({ message, nonce, recipient, callbackUrl, state }) {
-      logger.log("OptoWallet:signMessage", {
-        message,
-        nonce,
-        recipient,
-        callbackUrl,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/sender/src/lib/sender.ts
+++ b/packages/sender/src/lib/sender.ts
@@ -298,17 +298,6 @@ const Sender: WalletBehaviourFactory<InjectedWallet> = async ({
           return res.response;
         });
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Sender:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/wallet-connect/src/lib/wallet-connect.ts
+++ b/packages/wallet-connect/src/lib/wallet-connect.ts
@@ -616,17 +616,6 @@ const WalletConnect: WalletBehaviourFactory<
         return results;
       }
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("WalletConnect:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/welldone-wallet/src/lib/welldone.ts
+++ b/packages/welldone-wallet/src/lib/welldone.ts
@@ -355,17 +355,6 @@ const WelldoneWallet: WalletBehaviourFactory<InjectedWallet> = async ({
         params: [params],
       });
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Welldone:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 

--- a/packages/xdefi/src/lib/xdefi.ts
+++ b/packages/xdefi/src/lib/xdefi.ts
@@ -146,17 +146,6 @@ const XDEFI: WalletBehaviourFactory<InjectedWallet> = async ({
 
       return result;
     },
-
-    async signMessage({ message, nonce, recipient, state }) {
-      logger.log("Xdefi:signMessage", {
-        message,
-        nonce,
-        recipient,
-        state,
-      });
-
-      throw new Error(`Method not supported by ${metadata.name}`);
-    },
   };
 };
 


### PR DESCRIPTION
# Description

This PR removes the `signMessage` from a wallet that does not support this method (which throws by default) and **decorates** each module in the core package to throw a consistent message if the wallet does not support this method.

This has two benefits:

- If any wallet module doesn't implement the method for whatever reason, callers will always get a consistent error thrown instead of there being a `_signMessage is not a function` type of error thrown from our attempt to call it in those cases
- We don't need to inform wallet module authors about the need to add a stub, ensure their modules have the stub during code reviews, etc. -- we can treat the lack of implementation as a 'not supported'.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [ ] FIX - a PR of this type patches a bug.
- [x] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
