### PR TITLE
Define signMessage when accessing a wallet/module

### DIFF
--- a/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
+++ b/packages/core/src/lib/services/wallet-modules/wallet-modules.service.ts
@@ -22,6 +22,7 @@ import {
 } from "../../constants";
 import { JsonStorage } from "../storage/json-storage.service";
 import type { ProviderService } from "../provider/provider.service.types";
+import type { SignMessageMethod } from "../../wallet";
 
 export class WalletModules {
   private factories: Array<WalletModuleFactory>;
@@ -32,7 +33,7 @@ export class WalletModules {
   private provider: ProviderService;
 
   private modules: Array<ModuleState>;
-  private instances: Record<string, Wallet>;
+  private instances: Record<string, Wallet & SignMessageMethod>;
 
   constructor({
     factories,
@@ -289,7 +290,9 @@ export class WalletModules {
     return wallet;
   }
 
-  private async setupInstance(module: WalletModule): Promise<Wallet> {
+  private async setupInstance(
+    module: WalletModule
+  ): Promise<Wallet & SignMessageMethod> {
     if (!module.metadata.available) {
       const message =
         module.type === "injected" ? "not installed" : "not available";
@@ -313,7 +316,7 @@ export class WalletModules {
       })),
     } as Wallet;
 
-    return this.decorateWallet(wallet);
+    return this.decorateWallet(wallet) as Wallet & SignMessageMethod;
   }
 
   private getModule(id: string | null) {

--- a/packages/core/src/lib/store.types.ts
+++ b/packages/core/src/lib/store.types.ts
@@ -1,6 +1,7 @@
 import type { BehaviorSubject, Observable } from "rxjs";
 
 import type { Wallet, Account } from "./wallet";
+import type { SignMessageMethod } from "./wallet";
 
 export interface ContractState {
   contractId: string;
@@ -11,7 +12,7 @@ export type ModuleState<Variation extends Wallet = Wallet> = {
   id: Variation["id"];
   type: Variation["type"];
   metadata: Variation["metadata"];
-  wallet(): Promise<Variation>;
+  wallet(): Promise<Variation & SignMessageMethod>;
 };
 
 export type AccountState = Account & {

--- a/packages/core/src/lib/wallet-selector.types.ts
+++ b/packages/core/src/lib/wallet-selector.types.ts
@@ -7,6 +7,7 @@ import type { ReadOnlyStore } from "./store.types";
 import type { Network, NetworkId, Options } from "./options.types";
 import type { Subscription, StorageService } from "./services";
 import type { SupportedLanguage } from "./translate/translate";
+import type { SignMessageMethod } from "./wallet/wallet.types";
 
 export interface WalletSelectorParams {
   network: NetworkId | Network;
@@ -40,7 +41,9 @@ export interface WalletSelector {
   options: Options;
   store: WalletSelectorStore;
 
-  wallet<Variation extends Wallet = Wallet>(id?: string): Promise<Variation>;
+  wallet<Variation extends Wallet = Wallet>(
+    id?: string
+  ): Promise<Variation & SignMessageMethod>;
 
   isSignedIn(): boolean;
 

--- a/packages/core/src/lib/wallet/wallet.types.ts
+++ b/packages/core/src/lib/wallet/wallet.types.ts
@@ -59,6 +59,10 @@ export interface SignedMessage {
   state?: string;
 }
 
+export type SignMessageMethod = {
+  signMessage(params: SignMessageParams): Promise<SignedMessage | void>;
+};
+
 interface SignAndSendTransactionParams {
   signerId?: string;
   receiverId?: string;


### PR DESCRIPTION
This adds the signMessage at the types when getting the module/wallet from the selector at runtime so typescript does not complain and there is no need to check if this function is defined or not.

This fixes the case where the dApp developer in a TS project would have to check if `signMessage` is actually defined as described in this comment: https://github.com/Elabar/wallet-selector/pull/1#discussion_r1280423762 in the previous PR.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:
<!-- CHECKLIST_TYPE: ALL -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
<!-- /CHECKLIST_TYPE -->

# Type of change.
<!-- CHECKLIST_TYPE: ONE -->
- [x] FIX - a PR of this type patches a bug.
- [ ] FEATURE - a PR of this type introduces a new feature.
- [ ] BUILD - a PR of this type introduces build changes.
- [ ] CI - a PR of this type introduces CI changes.
- [ ] DOCS - a PR of this type introduces DOCS improvement.
- [ ] STYLE - a PR of this type introduces style changes.
- [ ] REFACTOR - a PR of this type introduces refactoring.
- [ ] PERFORMANCE - a PR of this type introduces performance changes.
- [ ] TEST - a PR of this type adds more tests.
- [ ] CHORE - a PR introduces other changes than the specified above.
<!-- /CHECKLIST_TYPE -->
